### PR TITLE
check if asset exists before asking for logicalPath

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -26,7 +26,7 @@ writeFiles = (bundles, sprockets, tmpPath) ->
   for bundle in bundles
     asset = sprockets.findAsset bundle
 
-    if asset.logicalPath?
+    if asset && asset.logicalPath?
       # write to file
       tmpFile = Path.join(tmpPath, asset.logicalPath)
       tmpFile = tmpFile.replace(/\.js\.coffee$/, '.js')


### PR DESCRIPTION
The current version of this statement breaks if asset is undefined,
it would be a good thing if it didn't. I think.