### PR TITLE
Allow object in the 'sprocketsBundles' array of the karma config file

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -24,7 +24,7 @@ writeFiles = (bundles, sprockets, tmpPath) ->
   writtenFiles = []
 
   for bundle in bundles
-    asset = sprockets.findAsset bundle
+    asset = sprockets.findAsset(if bundle.pattern? then bundle.pattern else bundle)
 
     if asset && asset.logicalPath?
       # write to file
@@ -37,7 +37,8 @@ writeFiles = (bundles, sprockets, tmpPath) ->
         Fs.mkdirSync(Path.dirname(tmpFile), 0o777, true)
 
       Fs.writeFileSync tmpFile, asset.toString()
-      writtenFiles.push tmpFile
+      tmpObject = pattern: tmpFile, included: bundle.included ?= true, served: bundle.served ?= true
+      writtenFiles.push(tmpObject)
     else
       console.log "Couldn't find asset: #{bundle}"
 
@@ -81,10 +82,10 @@ createSprockets = (config) ->
   paths = []
   for path in writeFiles(config.sprocketsBundles, sprockets, tmpPath)
     paths.push
-      included: true
-      served: true
+      included: path.included
+      served: path.served
       watched: config.autoWatch
-      pattern: path
+      pattern: path.pattern
 
   # put these files at the top of the files list
   config.files.unshift.apply(config.files, paths)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chokidar": "^1.0.0-rc3",
     "shelljs": "0.3.0",
     "mincer-fileskipper": "*",
+    "underscore": "*",
     "coffee-script": "*",
     "mincer-haml-coffee": "0.0.1"
   },


### PR DESCRIPTION
So we can control `included` and `served` options for each file/pattern of sprockets bundles.
E.G.
```javascript
    sprocketsBundles: [
      // this file will be served on demand from disk
      {pattern: 'application.js', included: false},
      // classic file, will be always served
      'test.js'
    ],
```

This feature is inspired by the one from the `files` array of the karma config file.
See: http://karma-runner.github.io/0.13/config/files.html