### PR TITLE
Only run `npm install` when required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.coffee
+++ b/index.coffee
@@ -4,6 +4,7 @@ Path = require('path')
 Chokidar = require('chokidar')
 Shell = require('shelljs')
 _ = require('underscore')
+CheckDependencies = require('check-dependencies')
 
 # Skip .erb files because Ruby <> JS
 require("mincer-fileskipper") Mincer, [".erb"]
@@ -77,7 +78,10 @@ createSprockets = (config) ->
       gemPath = output.trim()
 
       if Shell.test '-f', "#{gemPath}/package.json"
-        Shell.exec "cd #{gemPath}; npm install"
+        CheckDependencies.sync({
+          packageDir: gemPath,
+          install: true
+        })
 
       for path in sprocketsPaths
         console.log "Appending rubygem path: #{gemPath}/#{path}"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mincer-fileskipper": "*",
     "underscore": "*",
     "coffee-script": "*",
-    "mincer-haml-coffee": "0.0.1"
+    "mincer-haml-coffee": "0.0.1",
+    "check-dependencies": "^0.11.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This speeds up the init considerably for most cases (when there is nothing to be installed). The `check-dependencies` module will automatically run `npm install` if required.