### PR TITLE
Add helpers config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ sprocketsBundles: [
 ]
 ```
 
+Optionally configure helpers that the assets might be using.
+
+```coffeescript
+sprocketsHelpers:
+  asset_path: (fileName) -> return "assets/#{fileName}"
+```
+
 You can also add sprockets paths from RubyGems if you are using this in a Ruby/Rails project.
 
 ```coffeescript

--- a/index.coffee
+++ b/index.coffee
@@ -95,6 +95,10 @@ createSprockets = (config) ->
     # Add the path to the sprockets environment
     sprockets.appendPath(path)
 
+  # Register helpers if any
+  for helperName, helperValue of config.sprocketsHelpers
+    sprockets.registerHelper helperName, helperValue
+
   # Write out the bundle files to the tmp directory
   # Also, preserve the order of the bundles in the config file
   config.sprocketsBundles = writeFiles(config.sprocketsBundles, sprockets, tmpPath)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sprockets-mincer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.coffee",
   "keywords": [
     "karma",


### PR DESCRIPTION
This allows for configuration of helpers that the assets might be using. A specific usecase is `.ejs` files. 

For examples in a `template.jade.ejs` file:

```ejs
img(src="<%= asset_path('icons/arrow.png') %>")
```
