### PR TITLE
allow to specify additional engines for mincer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,14 @@ rubygems: {
 ```
 
 This will run grab the path of the bundled gem by running `bundle show` and add them with the specified paths to Sprockets/Mincer.
+
+If you need to use additional Mincer engines there is an option to bind extensions with externally defined engines.
+The path to engine file might be defined as absolute or relative to `basePath`.
+
+```coffeescript
+# "extension": "path-to-engine-definition-file.js"
+mincerEngines: {
+  ".hbs": "./lib/handlebarsjst.js",
+  ".xxx": "/opt/mincer-ext/engine.js"
+}
+```

--- a/index.coffee
+++ b/index.coffee
@@ -73,6 +73,14 @@ createSprockets = (config) ->
 
   tmpPath = process.cwd() + "/tmp/sprockets-mincer/"
 
+  # Add additional mincer engines
+  for extension, engine_path of config.mincerEngines
+    unless isAbsolutePath(engine_path)
+      engine_path = Path.join(config.basePath, engine_path)
+
+    engine = require(engine_path)
+    sprockets.registerEngine extension, engine
+  
   # Add the rubygem paths
   for gem, sprocketsPaths of config.rubygems
     {code, output} = Shell.exec "bundle show #{gem}", silent: true


### PR DESCRIPTION
These commits introduce support for external engines defined in project. This allows to compile i.e. `Handlebars` templates and add it to sprockets `bundle` file.