### PR TITLE
Bump check-dependencies to remove node >7 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "underscore": "*",
     "coffee-script": "*",
     "mincer-haml-coffee": "0.0.1",
-    "check-dependencies": "^0.11.0"
+    "check-dependencies": "^1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
>npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7
.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in t
he tree.